### PR TITLE
Rework mouse outline test to use metrics-based assertions

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,33 @@
+# Test Plan
+
+## Overview
+This repository now includes an automated Playwright smoke test that opens the
+existing `index.html` page in a headless Chromium browser and verifies the
+mouse-segmentation output. The goal is to catch regressions where the red
+outline disappears, becomes too thick, or shifts away from the mouse.
+
+## Test Suite
+
+### `tests/mouse-outline.spec.ts`
+* Launches a static HTTP server that serves the repository (via Playwright
+  `webServer`).
+* Loads `index.html`, waits for the OpenCV processing pipeline to finish, and
+  reads the `#output-canvas` pixel data.
+* Computes contour metrics (red pixel count, bounding box, horizontal and
+  vertical stroke width) to ensure the outline is tight, centered, and not
+  excessively thick in any direction.
+* Checks deterministic numeric guardrails (canvas size, red pixel totals,
+  bounding box limits, stroke run lengths, and outline coverage) so the test
+  stays fully text-based—no binary golden artifacts are required.
+
+## Usage
+
+```bash
+npm install
+npm test
+```
+
+`npm test` starts the local static server, runs the Playwright test, and then
+shuts the server down automatically. Because the assertions rely on measured
+metrics (rather than binary golden files), future updates only need to adjust
+the numeric thresholds if the expected outline geometry intentionally changes.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "codexplayground",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  fullyParallel: true,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    headless: true,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'python3 -m http.server 4173 --bind 127.0.0.1',
+    port: 4173,
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+});

--- a/tests/mouse-outline.spec.ts
+++ b/tests/mouse-outline.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test } from '@playwright/test';
+
+test('renders a tight red outline around the mouse sample', async ({ page }) => {
+  await page.goto('/index.html');
+
+  await page.waitForFunction(
+    'typeof alreadyProcessed !== "undefined" && alreadyProcessed === true',
+    { timeout: 60_000 }
+  );
+
+  // Give the rendering loop a short moment to settle so the canvas pixels are ready.
+  await page.waitForTimeout(500);
+
+  const metrics = await page.evaluate(() => {
+    const canvas = document.getElementById('output-canvas') as HTMLCanvasElement;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context is unavailable');
+    }
+
+    const { width, height } = canvas;
+    const pixels = ctx.getImageData(0, 0, width, height).data;
+
+    let redCount = 0;
+    let minX = width;
+    let minY = height;
+    let maxX = -1;
+    let maxY = -1;
+    let maxHorizontalRun = 0;
+    let maxVerticalRun = 0;
+    const firstRedByRow = new Array(height).fill(-1);
+    const lastRedByRow = new Array(height).fill(-1);
+    const firstRedByCol = new Array(width).fill(-1);
+    const lastRedByCol = new Array(width).fill(-1);
+
+    for (let y = 0; y < height; y++) {
+      let run = 0;
+      for (let x = 0; x < width; x++) {
+        const idx = (y * width + x) * 4;
+        const r = pixels[idx];
+        const g = pixels[idx + 1];
+        const b = pixels[idx + 2];
+        const isRed = r > 200 && g < 60 && b < 60;
+
+        if (isRed) {
+          redCount += 1;
+          run += 1;
+          if (x < minX) minX = x;
+          if (y < minY) minY = y;
+          if (x > maxX) maxX = x;
+          if (y > maxY) maxY = y;
+          if (firstRedByRow[y] === -1) firstRedByRow[y] = x;
+          lastRedByRow[y] = x;
+          if (firstRedByCol[x] === -1) firstRedByCol[x] = y;
+          lastRedByCol[x] = y;
+        } else {
+          if (run > maxHorizontalRun) {
+            maxHorizontalRun = run;
+          }
+          run = 0;
+        }
+      }
+      if (run > maxHorizontalRun) {
+        maxHorizontalRun = run;
+      }
+    }
+
+    for (let x = 0; x < width; x++) {
+      let run = 0;
+      for (let y = 0; y < height; y++) {
+        const idx = (y * width + x) * 4;
+        const r = pixels[idx];
+        const g = pixels[idx + 1];
+        const b = pixels[idx + 2];
+        const isRed = r > 200 && g < 60 && b < 60;
+
+        if (isRed) {
+          run += 1;
+        } else {
+          if (run > maxVerticalRun) {
+            maxVerticalRun = run;
+          }
+          run = 0;
+        }
+      }
+      if (run > maxVerticalRun) {
+        maxVerticalRun = run;
+      }
+    }
+
+    const boundingWidth = maxX >= minX ? maxX - minX + 1 : 0;
+    const boundingHeight = maxY >= minY ? maxY - minY + 1 : 0;
+    const boundingArea = boundingWidth * boundingHeight;
+    const canvasArea = width * height;
+    const boundingAreaRatio = canvasArea > 0 ? boundingArea / canvasArea : 0;
+    const coverageRatio = boundingArea > 0 ? redCount / boundingArea : 0;
+
+    let rowsWithOutline = 0;
+    let colsWithOutline = 0;
+    let maxRowLeadingGap = 0;
+    let maxRowTrailingGap = 0;
+    let maxColLeadingGap = 0;
+    let maxColTrailingGap = 0;
+
+    if (redCount > 0) {
+      for (let y = minY; y <= maxY; y++) {
+        const first = firstRedByRow[y];
+        const last = lastRedByRow[y];
+        if (first !== -1 && last !== -1) {
+          rowsWithOutline += 1;
+          if (first - minX > maxRowLeadingGap) {
+            maxRowLeadingGap = first - minX;
+          }
+          if (maxX - last > maxRowTrailingGap) {
+            maxRowTrailingGap = maxX - last;
+          }
+        }
+      }
+
+      for (let x = minX; x <= maxX; x++) {
+        const first = firstRedByCol[x];
+        const last = lastRedByCol[x];
+        if (first !== -1 && last !== -1) {
+          colsWithOutline += 1;
+          if (first - minY > maxColLeadingGap) {
+            maxColLeadingGap = first - minY;
+          }
+          if (maxY - last > maxColTrailingGap) {
+            maxColTrailingGap = maxY - last;
+          }
+        }
+      }
+    }
+
+    return {
+      width,
+      height,
+      redCount,
+      boundingWidth,
+      boundingHeight,
+      minX,
+      minY,
+      maxX,
+      maxY,
+      boundingArea,
+      boundingAreaRatio,
+      coverageRatio,
+      maxHorizontalRun,
+      maxVerticalRun,
+      rowsWithOutline,
+      colsWithOutline,
+      maxRowLeadingGap,
+      maxRowTrailingGap,
+      maxColLeadingGap,
+      maxColTrailingGap,
+    };
+  });
+
+  expect(metrics.width).toBeGreaterThan(0);
+  expect(metrics.height).toBeGreaterThan(0);
+  expect(metrics.width).toBe(220);
+  expect(metrics.height).toBe(293);
+
+  expect(metrics.redCount).toBeGreaterThanOrEqual(730);
+  expect(metrics.redCount).toBeLessThanOrEqual(820);
+
+  expect(metrics.maxHorizontalRun).toBeLessThanOrEqual(32);
+  expect(metrics.maxVerticalRun).toBeLessThanOrEqual(45);
+
+  expect(metrics.boundingWidth).toBeGreaterThanOrEqual(40);
+  expect(metrics.boundingWidth).toBeLessThanOrEqual(44);
+  expect(metrics.boundingHeight).toBeGreaterThanOrEqual(55);
+  expect(metrics.boundingHeight).toBeLessThanOrEqual(63);
+
+  expect(metrics.boundingAreaRatio).toBeGreaterThan(0.032);
+  expect(metrics.boundingAreaRatio).toBeLessThan(0.045);
+  expect(metrics.coverageRatio).toBeGreaterThan(0.28);
+  expect(metrics.coverageRatio).toBeLessThan(0.35);
+
+  expect(metrics.rowsWithOutline).toBeGreaterThanOrEqual(55);
+  expect(metrics.colsWithOutline).toBeGreaterThanOrEqual(40);
+
+  expect(metrics.minX).toBeGreaterThanOrEqual(95);
+  expect(metrics.minX).toBeLessThanOrEqual(105);
+  expect(metrics.maxX).toBeGreaterThanOrEqual(135);
+  expect(metrics.maxX).toBeLessThanOrEqual(145);
+  expect(metrics.minY).toBeGreaterThanOrEqual(110);
+  expect(metrics.minY).toBeLessThanOrEqual(125);
+  expect(metrics.maxY).toBeGreaterThanOrEqual(170);
+  expect(metrics.maxY).toBeLessThanOrEqual(185);
+
+  expect(metrics.maxRowLeadingGap).toBeLessThanOrEqual(22);
+  expect(metrics.maxRowTrailingGap).toBeLessThanOrEqual(22);
+  expect(metrics.maxColLeadingGap).toBeLessThanOrEqual(45);
+  expect(metrics.maxColTrailingGap).toBeLessThanOrEqual(45);
+});


### PR DESCRIPTION
## Summary
- replace the golden-image comparison with deterministic metrics that verify the red mouse outline
- extend the Playwright test with additional contour statistics to keep the outline thin and centered
- update the test plan to note the metric-based checks and remove references to binary fixtures

## Testing
- not run (Playwright dependencies are not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ea4e53d80883309367d623b7f5627b