### PR TITLE
Add documentation tab for detection walkthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+test-results/

--- a/index.html
+++ b/index.html
@@ -28,6 +28,59 @@
       align-items: flex-start;
     }
 
+    .tab-container {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .tab-buttons {
+      display: inline-flex;
+      border: 1px solid #d7d9e0;
+      background: #ffffff;
+      border-radius: 10px;
+      padding: 0.25rem;
+      box-shadow: 0 1px 4px rgba(15, 23, 42, 0.05);
+    }
+
+    .tab-button {
+      appearance: none;
+      border: none;
+      background: transparent;
+      font-size: 0.95rem;
+      font-weight: 600;
+      padding: 0.55rem 1.25rem;
+      border-radius: 8px;
+      color: #4f5466;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .tab-button:hover,
+    .tab-button:focus-visible {
+      background: #eef0ff;
+      color: #2f348f;
+      outline: none;
+    }
+
+    .tab-button.is-active {
+      background: #373de6;
+      color: #ffffff;
+      box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.14);
+    }
+
+    .tab-panel {
+      display: none;
+    }
+
+    .tab-panel[hidden] {
+      display: none !important;
+    }
+
+    .tab-panel:not([hidden]) {
+      display: block;
+    }
+
     .inputs {
       display: flex;
       flex-direction: column;
@@ -62,6 +115,61 @@
       height: auto;
       display: block;
       border-radius: 8px;
+    }
+
+    .markdown-body {
+      background: #ffffff;
+      border: 1px solid #d7d9e0;
+      border-radius: 12px;
+      padding: 2rem;
+      box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+      color: #1f1f1f;
+      line-height: 1.6;
+      max-width: 900px;
+    }
+
+    .markdown-body h1,
+    .markdown-body h2,
+    .markdown-body h3 {
+      font-weight: 700;
+      color: #2f348f;
+      margin-top: 1.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .markdown-body h1 {
+      font-size: 2rem;
+    }
+
+    .markdown-body h2 {
+      font-size: 1.5rem;
+    }
+
+    .markdown-body h3 {
+      font-size: 1.2rem;
+    }
+
+    .markdown-body p {
+      margin: 0.75rem 0;
+    }
+
+    .markdown-body ul,
+    .markdown-body ol {
+      margin: 0.75rem 0 0.75rem 1.5rem;
+      padding: 0;
+    }
+
+    .markdown-body li {
+      margin: 0.35rem 0;
+    }
+
+    .markdown-body code {
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      background: #f3f4fc;
+      color: #2f348f;
+      padding: 0.1rem 0.3rem;
+      border-radius: 4px;
+      font-size: 0.95rem;
     }
 
     .frame canvas {
@@ -113,50 +221,61 @@
 </head>
 <body>
   <h1 class="page-title">Codex Playground</h1>
-  <section class="gallery">
-    <div class="inputs">
-      <figure class="frame">
-        <figcaption>1. Mouse Input</figcaption>
-        <img id="original-img" src="input_mouse.jpeg" alt="Mouse input sample">
-      </figure>
-      <figure class="frame">
-        <figcaption>2. Coaster Input</figcaption>
-        <img id="coaster-img" src="input_coaster.jpeg" alt="Coaster input sample">
-      </figure>
-      <figure class="frame">
-        <figcaption>3. Remote Input</figcaption>
-        <img id="remote-img" src="input_remote.jpeg" alt="Remote input sample">
-      </figure>
-      <figure class="frame" id="custom-input-frame">
-        <figcaption>4. Upload Input</figcaption>
-        <div class="upload-control">
-          <label class="upload-button-label" for="custom-image-input">Choose Image</label>
-          <input id="custom-image-input" type="file" accept="image/*">
-          <p class="upload-hint">Upload a photo to detect and outline the main object.</p>
-          <img id="custom-img" alt="Uploaded input preview" hidden>
+  <div class="tab-container">
+    <div class="tab-buttons" role="tablist" aria-label="Object detection views">
+      <button id="tab-gallery" class="tab-button is-active" role="tab" aria-selected="true" aria-controls="panel-gallery" data-tab-target="gallery">Detection Gallery</button>
+      <button id="tab-explanation" class="tab-button" role="tab" aria-selected="false" aria-controls="panel-explanation" data-tab-target="explanation">How It Works</button>
+    </div>
+    <section id="panel-gallery" class="tab-panel" role="tabpanel" aria-labelledby="tab-gallery" data-tab="gallery">
+      <section class="gallery">
+        <div class="inputs">
+          <figure class="frame">
+            <figcaption>1. Mouse Input</figcaption>
+            <img id="original-img" src="input_mouse.jpeg" alt="Mouse input sample">
+          </figure>
+          <figure class="frame">
+            <figcaption>2. Coaster Input</figcaption>
+            <img id="coaster-img" src="input_coaster.jpeg" alt="Coaster input sample">
+          </figure>
+          <figure class="frame">
+            <figcaption>3. Remote Input</figcaption>
+            <img id="remote-img" src="input_remote.jpeg" alt="Remote input sample">
+          </figure>
+          <figure class="frame" id="custom-input-frame">
+            <figcaption>4. Upload Input</figcaption>
+            <div class="upload-control">
+              <label class="upload-button-label" for="custom-image-input">Choose Image</label>
+              <input id="custom-image-input" type="file" accept="image/*">
+              <p class="upload-hint">Upload a photo to detect and outline the main object.</p>
+              <img id="custom-img" alt="Uploaded input preview" hidden>
+            </div>
+          </figure>
         </div>
-      </figure>
-    </div>
-    <div class="outputs">
-      <figure class="frame">
-        <figcaption>Mouse Output</figcaption>
-        <canvas id="output-canvas"></canvas>
-      </figure>
-      <figure class="frame">
-        <figcaption>Coaster Output</figcaption>
-        <canvas id="coaster-output-canvas"></canvas>
-      </figure>
-      <figure class="frame">
-        <figcaption>Remote Output</figcaption>
-        <canvas id="remote-output-canvas"></canvas>
-      </figure>
-      <figure class="frame" id="custom-output-frame" hidden>
-        <figcaption>Upload Output</figcaption>
-        <canvas id="custom-output-canvas"></canvas>
-      </figure>
-    </div>
-  </section>
-  <main id="app"></main>
+        <div class="outputs">
+          <figure class="frame">
+            <figcaption>Mouse Output</figcaption>
+            <canvas id="output-canvas"></canvas>
+          </figure>
+          <figure class="frame">
+            <figcaption>Coaster Output</figcaption>
+            <canvas id="coaster-output-canvas"></canvas>
+          </figure>
+          <figure class="frame">
+            <figcaption>Remote Output</figcaption>
+            <canvas id="remote-output-canvas"></canvas>
+          </figure>
+          <figure class="frame" id="custom-output-frame" hidden>
+            <figcaption>Upload Output</figcaption>
+            <canvas id="custom-output-canvas"></canvas>
+          </figure>
+        </div>
+      </section>
+      <main id="app"></main>
+    </section>
+    <section id="panel-explanation" class="tab-panel" role="tabpanel" aria-labelledby="tab-explanation" data-tab="explanation" hidden>
+      <article id="explanation-markdown" class="markdown-body" aria-live="polite"></article>
+    </section>
+  </div>
   <script defer src="https://docs.opencv.org/4.x/opencv.js"></script>
   <script defer src="main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a tabbed layout so users can switch between the detection gallery and documentation
- render a markdown-formatted walkthrough that explains each object-detection pipeline step
- ignore local Playwright outputs to avoid committing test artifacts

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2493bd5dc8330b801ec7c0042eccd