### PR TITLE
Nest mouse processing steps behind collapsible panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,18 @@
       box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
     }
 
+    .output-frame {
+      width: 260px;
+    }
+
     .frame figcaption {
       font-size: 0.95rem;
       font-weight: 600;
       margin-bottom: 0.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
     }
 
     .frame img,
@@ -65,6 +73,64 @@
     }
 
     .frame canvas {
+      background: #f0f1f6;
+    }
+
+    .frame figcaption .step-toggle {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #3d45d0;
+      background: rgba(61, 69, 208, 0.08);
+      border: 1px solid rgba(61, 69, 208, 0.2);
+      border-radius: 999px;
+      padding: 0.25rem 0.75rem;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease;
+    }
+
+    .frame figcaption .step-toggle:hover,
+    .frame figcaption .step-toggle:focus {
+      outline: none;
+      background: rgba(61, 69, 208, 0.15);
+      border-color: rgba(61, 69, 208, 0.35);
+    }
+
+    .frame figcaption .step-toggle:focus-visible {
+      box-shadow: 0 0 0 3px rgba(61, 69, 208, 0.35);
+    }
+
+    .processing-panel {
+      margin-top: 0.75rem;
+      padding: 0.75rem;
+      background: #f4f5fb;
+      border: 1px solid #e0e2f1;
+      border-radius: 10px;
+    }
+
+    .processing-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 0.75rem;
+    }
+
+    .step-frame {
+      border: 1px solid #d7d9e0;
+      border-radius: 10px;
+      padding: 0.5rem;
+      background: #ffffff;
+      box-shadow: 0 1px 4px rgba(15, 23, 42, 0.05);
+    }
+
+    .step-frame figcaption {
+      font-size: 0.8rem;
+      font-weight: 600;
+      margin-bottom: 0.35rem;
+      display: block;
+    }
+
+    .step-frame canvas {
+      width: 100%;
+      border-radius: 6px;
       background: #f0f1f6;
     }
 
@@ -138,19 +204,55 @@
       </figure>
     </div>
     <div class="outputs">
-      <figure class="frame">
-        <figcaption>Mouse Output</figcaption>
+      <figure class="frame output-frame">
+        <figcaption>
+          <span>Mouse Output</span>
+          <button
+            class="step-toggle"
+            type="button"
+            data-step-toggle="mouse-processing-steps"
+            data-show-label="Show steps"
+            data-hide-label="Hide steps"
+            aria-expanded="false"
+          >
+            Show steps
+          </button>
+        </figcaption>
         <canvas id="output-canvas"></canvas>
+        <div id="mouse-processing-steps" class="processing-panel" hidden>
+          <div class="processing-grid">
+            <figure class="step-frame">
+              <figcaption>Step 1. Prepared Frame</figcaption>
+              <canvas id="mouse-step-resized"></canvas>
+            </figure>
+            <figure class="step-frame">
+              <figcaption>Step 2. Grayscale</figcaption>
+              <canvas id="mouse-step-gray"></canvas>
+            </figure>
+            <figure class="step-frame">
+              <figcaption>Step 3. Blurred Gray</figcaption>
+              <canvas id="mouse-step-blur"></canvas>
+            </figure>
+            <figure class="step-frame">
+              <figcaption>Step 4. Object Mask</figcaption>
+              <canvas id="mouse-step-mask"></canvas>
+            </figure>
+            <figure class="step-frame">
+              <figcaption>Step 5. Binary Contours</figcaption>
+              <canvas id="mouse-step-contours"></canvas>
+            </figure>
+          </div>
+        </div>
       </figure>
-      <figure class="frame">
+      <figure class="frame output-frame">
         <figcaption>Coaster Output</figcaption>
         <canvas id="coaster-output-canvas"></canvas>
       </figure>
-      <figure class="frame">
+      <figure class="frame output-frame">
         <figcaption>Remote Output</figcaption>
         <canvas id="remote-output-canvas"></canvas>
       </figure>
-      <figure class="frame" id="custom-output-frame" hidden>
+      <figure class="frame output-frame" id="custom-output-frame" hidden>
         <figcaption>Upload Output</figcaption>
         <canvas id="custom-output-canvas"></canvas>
       </figure>


### PR DESCRIPTION
## Summary
- replace the standalone mouse processing column with a collapsible panel attached to the mouse output frame
- add reusable styling and toggle logic so future output cards can host their own step panels

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f249c577608330acc782ca1eef6e25